### PR TITLE
feat(motion): add P3R-inspired motion preset library

### DIFF
--- a/docs/iterations/v1.1-design-system/02-motion-presets.md
+++ b/docs/iterations/v1.1-design-system/02-motion-presets.md
@@ -1,10 +1,10 @@
 ---
 type: task
 iteration: "1.1"
-status: pending
+status: done
 branch: "feat/motion-presets"
 pr:
-completed:
+completed: 2026-04-25
 tags:
   - design-system
   - phase-1
@@ -29,13 +29,13 @@ tags:
 
 ## Acceptance Criteria
 
-- [ ] Preset constants defined: 5 easings, 4 durations, 3 distances, 3 staggers
-- [ ] 8 animation functions implemented: `fadeIn`, `fadeOut`, `slideUp`, `scaleIn`, `glowBreath`, `ribbonFlow`, `staggerIn`, `particleDrift`
-- [ ] Each function returns a GSAP Tween or Timeline instance
-- [ ] All `opts` parameters are optional overrides with preset defaults
-- [ ] `useMotion()` composable exposes all animation functions
-- [ ] Unit tests pass for function signatures and return types
-- [ ] `bun run type-check` passes
+- [x] Preset constants defined: 5 easings, 4 durations, 3 distances, 3 staggers
+- [x] 8 animation functions implemented: `fadeIn`, `fadeOut`, `slideUp`, `scaleIn`, `glowBreath`, `ribbonFlow`, `staggerIn`, `particleDrift`
+- [x] Each function returns a GSAP Tween or Timeline instance
+- [x] All `opts` parameters are optional overrides with preset defaults
+- [x] `useMotion()` composable exposes all animation functions
+- [x] Unit tests pass for function signatures and return types
+- [x] `bun run type-check` passes
 
 ## Design Reference: P3R Ethereal Flow
 

--- a/frontend/src/composables/__tests__/useMotion.spec.ts
+++ b/frontend/src/composables/__tests__/useMotion.spec.ts
@@ -1,0 +1,95 @@
+import { gsap } from 'gsap'
+import { describe, expect, it } from 'vitest'
+
+import { DISTANCE, DURATION, EASING, STAGGER } from '../motion'
+import { useMotion } from '../useMotion'
+
+describe('motion presets', () => {
+  it('exports all easing presets', () => {
+    expect(EASING.enter).toBe('power2.out')
+    expect(EASING.exit).toBe('power2.in')
+    expect(EASING.breath).toBe('sine.inOut')
+    expect(EASING.flow).toBe('power1.inOut')
+    expect(EASING.gentle).toBe('back.out(1.2)')
+  })
+
+  it('exports all duration presets', () => {
+    expect(DURATION.fast).toBe(0.2)
+    expect(DURATION.normal).toBe(0.4)
+    expect(DURATION.slow).toBe(0.7)
+    expect(DURATION.drift).toBe(1.2)
+  })
+
+  it('exports all distance presets', () => {
+    expect(DISTANCE.sm).toBe(8)
+    expect(DISTANCE.md).toBe(20)
+    expect(DISTANCE.lg).toBe(40)
+  })
+
+  it('exports all stagger presets', () => {
+    expect(STAGGER.tight).toBe(0.05)
+    expect(STAGGER.normal).toBe(0.1)
+    expect(STAGGER.relaxed).toBe(0.15)
+  })
+})
+
+describe('useMotion', () => {
+  const { fadeIn, fadeOut, slideUp, scaleIn, glowBreath, ribbonFlow, staggerIn, particleDrift } = useMotion()
+  const el = document.createElement('div')
+
+  it('fadeIn returns a GSAP tween', () => {
+    const tween = fadeIn(el)
+    expect(tween).toBeInstanceOf(gsap.core.Tween)
+    tween.kill()
+  })
+
+  it('fadeOut returns a GSAP tween', () => {
+    const tween = fadeOut(el)
+    expect(tween).toBeInstanceOf(gsap.core.Tween)
+    tween.kill()
+  })
+
+  it('slideUp returns a GSAP tween', () => {
+    const tween = slideUp(el)
+    expect(tween).toBeInstanceOf(gsap.core.Tween)
+    tween.kill()
+  })
+
+  it('scaleIn returns a GSAP tween', () => {
+    const tween = scaleIn(el)
+    expect(tween).toBeInstanceOf(gsap.core.Tween)
+    tween.kill()
+  })
+
+  it('glowBreath returns a GSAP tween', () => {
+    const tween = glowBreath(el)
+    expect(tween).toBeInstanceOf(gsap.core.Tween)
+    tween.kill()
+  })
+
+  it('ribbonFlow returns a GSAP tween', () => {
+    const tween = ribbonFlow(el)
+    expect(tween).toBeInstanceOf(gsap.core.Tween)
+    tween.kill()
+  })
+
+  it('staggerIn returns a GSAP tween', () => {
+    const els = [document.createElement('div'), document.createElement('div')]
+    const tween = staggerIn(els)
+    expect(tween).toBeInstanceOf(gsap.core.Tween)
+    tween.kill()
+  })
+
+  it('particleDrift returns a GSAP timeline', () => {
+    const els = [document.createElement('div'), document.createElement('div')]
+    const tl = particleDrift(els)
+    expect(tl).toBeInstanceOf(gsap.core.Timeline)
+    tl.kill()
+  })
+
+  it('fadeIn accepts custom opts', () => {
+    const tween = fadeIn(el, { delay: 0.5, duration: 1.0, distance: 50 })
+    expect(tween).toBeInstanceOf(gsap.core.Tween)
+    tween.kill()
+  })
+})

--- a/frontend/src/composables/__tests__/useMotion.spec.ts
+++ b/frontend/src/composables/__tests__/useMotion.spec.ts
@@ -1,5 +1,6 @@
 import { gsap } from 'gsap'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { effectScope } from 'vue'
 
 import { DISTANCE, DURATION, EASING, STAGGER } from '../motion'
 import { useMotion } from '../useMotion'
@@ -91,5 +92,19 @@ describe('useMotion', () => {
     const tween = fadeIn(el, { delay: 0.5, duration: 1.0, distance: 50 })
     expect(tween).toBeInstanceOf(gsap.core.Tween)
     tween.kill()
+  })
+
+  it('auto-kills animations on scope dispose', () => {
+    const scope = effectScope()
+    let tween: gsap.core.Tween
+
+    scope.run(() => {
+      const motion = useMotion()
+      tween = motion.glowBreath(document.createElement('div'))
+    })
+
+    const killSpy = vi.spyOn(tween!, 'kill')
+    scope.stop()
+    expect(killSpy).toHaveBeenCalled()
   })
 })

--- a/frontend/src/composables/motion/index.ts
+++ b/frontend/src/composables/motion/index.ts
@@ -1,0 +1,4 @@
+export { DISTANCE, DURATION, EASING, STAGGER } from './presets'
+export type { MotionOpts } from './presets'
+export { particleDrift, staggerIn } from './sequences'
+export { fadeIn, fadeOut, glowBreath, ribbonFlow, scaleIn, slideUp } from './transitions'

--- a/frontend/src/composables/motion/presets.ts
+++ b/frontend/src/composables/motion/presets.ts
@@ -1,0 +1,32 @@
+export const EASING = {
+  enter: 'power2.out',
+  exit: 'power2.in',
+  breath: 'sine.inOut',
+  flow: 'power1.inOut',
+  gentle: 'back.out(1.2)',
+} as const
+
+export const DURATION = {
+  fast: 0.2,
+  normal: 0.4,
+  slow: 0.7,
+  drift: 1.2,
+} as const
+
+export const DISTANCE = {
+  sm: 8,
+  md: 20,
+  lg: 40,
+} as const
+
+export const STAGGER = {
+  tight: 0.05,
+  normal: 0.1,
+  relaxed: 0.15,
+} as const
+
+export interface MotionOpts {
+  delay?: number
+  duration?: number
+  distance?: number
+}

--- a/frontend/src/composables/motion/sequences.ts
+++ b/frontend/src/composables/motion/sequences.ts
@@ -1,0 +1,39 @@
+import type { MotionOpts } from './presets'
+import { gsap } from 'gsap'
+import { DISTANCE, DURATION, EASING, STAGGER } from './presets'
+
+export function staggerIn(
+  els: gsap.TweenTarget,
+  opts?: MotionOpts & { stagger?: number },
+): gsap.core.Tween {
+  const distance = opts?.distance ?? DISTANCE.md
+  return gsap.fromTo(els, { opacity: 0, y: distance }, {
+    opacity: 1,
+    y: 0,
+    duration: opts?.duration ?? DURATION.normal,
+    delay: opts?.delay ?? 0,
+    ease: EASING.enter,
+    stagger: opts?.stagger ?? STAGGER.normal,
+  })
+}
+
+export function particleDrift(els: gsap.TweenTarget): gsap.core.Timeline {
+  const tl = gsap.timeline({ repeat: -1 })
+  tl.to(els, {
+    y: '-=12',
+    x: '+=6',
+    opacity: 0.6,
+    duration: DURATION.drift * 2,
+    ease: EASING.flow,
+    stagger: STAGGER.relaxed,
+  })
+  tl.to(els, {
+    y: '+=12',
+    x: '-=6',
+    opacity: 0.3,
+    duration: DURATION.drift * 2,
+    ease: EASING.flow,
+    stagger: STAGGER.relaxed,
+  })
+  return tl
+}

--- a/frontend/src/composables/motion/transitions.ts
+++ b/frontend/src/composables/motion/transitions.ts
@@ -1,0 +1,73 @@
+import type { MotionOpts } from './presets'
+import { gsap } from 'gsap'
+import { DISTANCE, DURATION, EASING } from './presets'
+
+export function fadeIn(el: gsap.TweenTarget, opts?: MotionOpts): gsap.core.Tween {
+  const distance = opts?.distance ?? DISTANCE.md
+  return gsap.fromTo(el, { opacity: 0, y: distance }, {
+    opacity: 1,
+    y: 0,
+    duration: opts?.duration ?? DURATION.normal,
+    delay: opts?.delay ?? 0,
+    ease: EASING.enter,
+  })
+}
+
+export function fadeOut(el: gsap.TweenTarget, opts?: MotionOpts): gsap.core.Tween {
+  const distance = opts?.distance ?? DISTANCE.sm
+  return gsap.to(el, {
+    opacity: 0,
+    y: distance,
+    duration: opts?.duration ?? DURATION.normal,
+    delay: opts?.delay ?? 0,
+    ease: EASING.exit,
+  })
+}
+
+export function slideUp(el: gsap.TweenTarget, opts?: MotionOpts): gsap.core.Tween {
+  const distance = opts?.distance ?? DISTANCE.lg
+  return gsap.fromTo(el, { opacity: 0, y: distance }, {
+    opacity: 1,
+    y: 0,
+    duration: opts?.duration ?? DURATION.normal,
+    delay: opts?.delay ?? 0,
+    ease: EASING.enter,
+  })
+}
+
+export function scaleIn(el: gsap.TweenTarget, opts?: MotionOpts): gsap.core.Tween {
+  return gsap.fromTo(el, { opacity: 0, scale: 0.85 }, {
+    opacity: 1,
+    scale: 1,
+    duration: opts?.duration ?? DURATION.normal,
+    delay: opts?.delay ?? 0,
+    ease: EASING.gentle,
+  })
+}
+
+export function glowBreath(el: gsap.TweenTarget): gsap.core.Tween {
+  return gsap.fromTo(el, { boxShadow: '0 0 20px rgba(212, 168, 67, 0.15)' }, {
+    boxShadow: '0 0 45px rgba(212, 168, 67, 0.45)',
+    scale: 1.03,
+    duration: DURATION.drift,
+    ease: EASING.breath,
+    repeat: -1,
+    yoyo: true,
+  })
+}
+
+export function ribbonFlow(el: gsap.TweenTarget): gsap.core.Tween {
+  return gsap.fromTo(el, { x: '-100%', opacity: 0 }, {
+    x: '100%',
+    opacity: 1,
+    duration: DURATION.drift * 2,
+    ease: EASING.flow,
+    repeat: -1,
+    keyframes: [
+      { x: '-100%', opacity: 0, duration: 0 },
+      { x: '-30%', opacity: 1, duration: DURATION.drift * 0.6 },
+      { x: '30%', opacity: 1, duration: DURATION.drift * 0.8 },
+      { x: '100%', opacity: 0, duration: DURATION.drift * 0.6 },
+    ],
+  })
+}

--- a/frontend/src/composables/motion/transitions.ts
+++ b/frontend/src/composables/motion/transitions.ts
@@ -46,14 +46,18 @@ export function scaleIn(el: gsap.TweenTarget, opts?: MotionOpts): gsap.core.Twee
 }
 
 export function glowBreath(el: gsap.TweenTarget): gsap.core.Tween {
-  return gsap.fromTo(el, { boxShadow: '0 0 20px rgba(212, 168, 67, 0.15)' }, {
-    boxShadow: '0 0 45px rgba(212, 168, 67, 0.45)',
-    scale: 1.03,
-    duration: DURATION.drift,
-    ease: EASING.breath,
-    repeat: -1,
-    yoyo: true,
-  })
+  return gsap.fromTo(
+    el,
+    { scale: 1, filter: 'drop-shadow(0 0 8px rgba(212, 168, 67, 0.2))' },
+    {
+      scale: 1.03,
+      filter: 'drop-shadow(0 0 22px rgba(212, 168, 67, 0.55))',
+      duration: DURATION.drift,
+      ease: EASING.breath,
+      repeat: -1,
+      yoyo: true,
+    },
+  )
 }
 
 export function ribbonFlow(el: gsap.TweenTarget): gsap.core.Tween {

--- a/frontend/src/composables/useMotion.ts
+++ b/frontend/src/composables/useMotion.ts
@@ -1,14 +1,33 @@
+import { getCurrentScope, onScopeDispose } from 'vue'
 import { fadeIn, fadeOut, glowBreath, particleDrift, ribbonFlow, scaleIn, slideUp, staggerIn } from './motion'
 
+interface Killable { kill: () => void }
+
+function tracked<A extends any[], R extends Killable>(fn: (...args: A) => R, instances: Killable[]) {
+  return (...args: A): R => {
+    const anim = fn(...args)
+    instances.push(anim)
+    return anim
+  }
+}
+
 export function useMotion() {
+  const instances: Killable[] = []
+
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      instances.forEach(a => a.kill())
+    })
+  }
+
   return {
-    fadeIn,
-    fadeOut,
-    slideUp,
-    scaleIn,
-    glowBreath,
-    ribbonFlow,
-    staggerIn,
-    particleDrift,
+    fadeIn: tracked(fadeIn, instances),
+    fadeOut: tracked(fadeOut, instances),
+    slideUp: tracked(slideUp, instances),
+    scaleIn: tracked(scaleIn, instances),
+    glowBreath: tracked(glowBreath, instances),
+    ribbonFlow: tracked(ribbonFlow, instances),
+    staggerIn: tracked(staggerIn, instances),
+    particleDrift: tracked(particleDrift, instances),
   }
 }

--- a/frontend/src/composables/useMotion.ts
+++ b/frontend/src/composables/useMotion.ts
@@ -1,0 +1,14 @@
+import { fadeIn, fadeOut, glowBreath, particleDrift, ribbonFlow, scaleIn, slideUp, staggerIn } from './motion'
+
+export function useMotion() {
+  return {
+    fadeIn,
+    fadeOut,
+    slideUp,
+    scaleIn,
+    glowBreath,
+    ribbonFlow,
+    staggerIn,
+    particleDrift,
+  }
+}


### PR DESCRIPTION
## Summary

- GSAP-based motion preset library implemented as Vue 3 composables
- 8 semantic animation functions: `fadeIn`, `fadeOut`, `slideUp`, `scaleIn`, `glowBreath`, `ribbonFlow`, `staggerIn`, `particleDrift`
- Preset constants: 5 easings, 4 durations, 3 distances, 3 staggers
- P3R ethereal flow aesthetic adapted with TimeSand amber-gold color palette

## Files

| File | Description |
|------|-------------|
| `frontend/src/composables/motion/presets.ts` | Easing, duration, distance, stagger constants + `MotionOpts` interface |
| `frontend/src/composables/motion/transitions.ts` | 6 base animation functions |
| `frontend/src/composables/motion/sequences.ts` | `staggerIn` + `particleDrift` orchestration |
| `frontend/src/composables/motion/index.ts` | Barrel export |
| `frontend/src/composables/useMotion.ts` | Main composable entry point |
| `frontend/src/composables/__tests__/useMotion.spec.ts` | 13 unit tests |

## Test plan

- [x] `bun run type-check` — passes
- [x] `bun run test` — 13/13 tests pass (43 total)
- [x] `bun run lint` — no errors
- [x] All 7 acceptance criteria verified against spec