### PR TITLE
fix: onboarding 不再被底部播放器遮挡

### DIFF
--- a/frontend/src/components/MusicPlayer.vue
+++ b/frontend/src/components/MusicPlayer.vue
@@ -7,9 +7,8 @@ import { useMusicPlayer } from '../composables/useMusicPlayer'
 const EXPAND_STORAGE_KEY = 'ts-player-expanded'
 const MAIN_PADDING_VARIABLE = '--ts-player-main-padding'
 const MOBILE_MEDIA_QUERY = '(max-width: 767px)'
-const COLLAPSED_PADDING = '5rem'
-const MOBILE_EXPANDED_PADDING = '14.5rem'
-const EXPANDED_PADDING = '10rem'
+const FALLBACK_MAIN_PADDING = '5rem'
+const MAIN_PADDING_EXTRA_PX = 16
 
 const { t } = useI18n()
 
@@ -35,6 +34,7 @@ const {
 const isExpanded = ref(false)
 const isMobileExpanded = ref(false)
 const isMobileViewport = ref(false)
+const playerRootRef = ref<HTMLElement | null>(null)
 const mobileExpandedRef = ref<HTMLElement | null>(null)
 const mobileExpandedInnerRef = ref<HTMLElement | null>(null)
 const hasTracks = computed(() => tracks.value.length > 0)
@@ -83,19 +83,34 @@ const mobileMiniSafeAreaStyle = computed(() => ({
 
 let mobileMediaQueryList: MediaQueryList | null = null
 let mobileMediaQueryListener: ((event: MediaQueryListEvent) => void) | null = null
+let playerResizeObserver: ResizeObserver | null = null
 let mobilePanelReady = false
 
 function syncMainPadding(): void {
-  const isPanelExpanded = isMobileViewport.value ? isMobileExpanded.value : isExpanded.value
-  const padding = isMobileViewport.value
-    ? isPanelExpanded && hasTracks.value
-      ? MOBILE_EXPANDED_PADDING
-      : COLLAPSED_PADDING
-    : isPanelExpanded && hasTracks.value
-      ? EXPANDED_PADDING
-      : COLLAPSED_PADDING
+  const playerHeight = playerRootRef.value?.getBoundingClientRect().height ?? 0
+  if (playerHeight <= 0) {
+    document.documentElement.style.setProperty(MAIN_PADDING_VARIABLE, FALLBACK_MAIN_PADDING)
+    return
+  }
 
-  document.documentElement.style.setProperty(MAIN_PADDING_VARIABLE, padding)
+  const paddingPx = Math.ceil(playerHeight + MAIN_PADDING_EXTRA_PX)
+  document.documentElement.style.setProperty(MAIN_PADDING_VARIABLE, `${paddingPx}px`)
+}
+
+function setupPlayerResizeObserver(): void {
+  if (typeof ResizeObserver === 'undefined') {
+    return
+  }
+
+  const playerRoot = playerRootRef.value
+  if (!playerRoot) {
+    return
+  }
+
+  playerResizeObserver = new ResizeObserver(() => {
+    syncMainPadding()
+  })
+  playerResizeObserver.observe(playerRoot)
 }
 
 function readStoredExpanded(): boolean {
@@ -266,9 +281,10 @@ function setupMobileMediaQuery(): void {
 onMounted(async () => {
   isExpanded.value = readStoredExpanded()
   setupMobileMediaQuery()
-  syncMainPadding()
   await nextTick()
   syncMobileExpandedVisibility()
+  setupPlayerResizeObserver()
+  syncMainPadding()
   mobilePanelReady = true
 })
 
@@ -296,6 +312,8 @@ watch(() => isMobileExpanded.value && hasTracks.value, (shouldExpand) => {
 
 onBeforeUnmount(() => {
   document.documentElement.style.removeProperty(MAIN_PADDING_VARIABLE)
+  playerResizeObserver?.disconnect()
+  playerResizeObserver = null
 
   if (mobileMediaQueryList && mobileMediaQueryListener) {
     if (typeof mobileMediaQueryList.removeEventListener === 'function') {
@@ -318,6 +336,7 @@ onBeforeUnmount(() => {
 
 <template>
   <section
+    ref="playerRootRef"
     data-testid="music-player"
     :data-expanded="expandedState"
     class="border-t border-white/10 bg-ts-panel/95 text-ts-text shadow-[0_-8px_24px_rgba(0,0,0,0.35)] backdrop-blur"

--- a/frontend/src/components/OnboardingOverlay.vue
+++ b/frontend/src/components/OnboardingOverlay.vue
@@ -270,7 +270,10 @@ onBeforeUnmount(() => {
       :style="spotlightStyle"
     />
 
-    <div class="relative flex min-h-full items-center justify-center px-4 py-8">
+    <div
+      class="relative flex min-h-full items-start justify-center overflow-y-auto px-4 py-6"
+      :style="{ paddingBottom: 'calc(var(--ts-player-main-padding, 5rem) + 1rem)' }"
+    >
       <section
         ref="panelRef"
         class="relative w-full max-w-lg overflow-hidden rounded-ts-lg border border-ts-border bg-ts-panel px-6 py-6 shadow-ts-md md:px-8 md:py-8"

--- a/frontend/src/components/__tests__/MusicPlayer.spec.ts
+++ b/frontend/src/components/__tests__/MusicPlayer.spec.ts
@@ -147,6 +147,47 @@ describe('musicPlayer', () => {
     expect(wrapper.find('[data-testid="music-player"]').attributes('data-expanded')).toBe('false')
   })
 
+  it('updates main padding variable from measured player height', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+
+    const store = usePlayerStore()
+    store.loadPlaylist({
+      playlistId: 1,
+      playlistName: 'Default Playlist',
+      tracks: [
+        {
+          id: 1,
+          title: 'Quiet Sea',
+          artist: 'TimeSand',
+          filename: 'quiet-sea.mp3',
+          file_path: 'quiet-sea.mp3',
+          file_size: 1024,
+          duration: 110,
+          mime_type: 'audio/mpeg',
+          uploaded_at: '2026-04-10T09:00:00Z',
+        },
+      ],
+    })
+
+    const wrapper = mountWithI18n(MusicPlayer, {
+      global: {
+        plugins: [pinia],
+      },
+    })
+    await nextTick()
+
+    const root = wrapper.get('[data-testid="music-player"]').element as HTMLElement
+    vi.spyOn(root, 'getBoundingClientRect').mockReturnValue(
+      new DOMRect(0, 0, 1200, 111),
+    )
+
+    await wrapper.find('[data-testid="music-player-expand-toggle"]').trigger('click')
+    await nextTick()
+
+    expect(document.documentElement.style.getPropertyValue('--ts-player-main-padding')).toBe('127px')
+  })
+
   it('renders mobile mini bar by default on small viewports', () => {
     stubViewport(true)
 

--- a/frontend/src/pages/HomePage.vue
+++ b/frontend/src/pages/HomePage.vue
@@ -434,7 +434,7 @@ watch(
       <h1 class="text-3xl font-semibold text-ts-accent">
         {{ $t('draw.title') }}
       </h1>
-      <p class="text-sm text-ts-muted">
+      <p class="text-sm text-ts-text/80">
         {{ $t('draw.description') }}
       </p>
 
@@ -468,14 +468,14 @@ watch(
 
         <button
           type="button"
-          class="rounded border border-white/20 px-4 py-2 text-sm font-semibold text-ts-text transition hover:border-white/40 hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60"
+          class="rounded border border-white/30 px-4 py-2 text-sm font-semibold text-ts-text/95 transition hover:border-white/50 hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60"
           :disabled="!hasDrawnCards || isDrawing"
           @click="reshuffle"
         >
           {{ $t('draw.reshuffle') }}
         </button>
 
-        <p class="text-xs text-ts-muted md:ml-auto">
+        <p class="text-xs text-ts-text/75 md:ml-auto">
           {{ $t('draw.swipeHint') }}
         </p>
       </div>


### PR DESCRIPTION
## Summary
- Make main content bottom padding follow real music player height (instead of fixed value), so short desktop viewports still reserve enough safe area.
- Update onboarding overlay layout to support scroll and bottom safe padding above the player.
- Improve readability for draw-page secondary texts (draw.description, Reshuffle, swipe hint).
- Add a test to verify --ts-player-main-padding is updated from measured player height.

## Issue Link
Closes #56
Related to #57

## Scope Decision
- #57 is intentionally **not fixed** in this PR based on product decision: desktop users can scroll down to access the card pile (same interaction model as mobile).