### PR TITLE
fix: resolve P1 bugs and add onboarding debug route

### DIFF
--- a/backend/app/api/albums.py
+++ b/backend/app/api/albums.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import delete, func
 from sqlmodel import Session, select
 
@@ -17,12 +17,12 @@ router = APIRouter(prefix="/api/albums", tags=["albums"])
 
 
 class AlbumCreateRequest(BaseModel):
-    name: str
+    name: str = Field(max_length=255)
     description: str | None = None
 
 
 class AlbumUpdateRequest(BaseModel):
-    name: str
+    name: str = Field(max_length=255)
     description: str | None = None
     cover_photo_id: int | None = None
 
@@ -256,8 +256,10 @@ def remove_photo_from_album(
             PhotoAlbum.photo_id == photo_id,
         )
     ).first()
-    if link is not None:
-        session.delete(link)
+    if link is None:
+        raise HTTPException(status_code=404, detail="Photo is not in album")
+
+    session.delete(link)
 
     if album.cover_photo_id == photo_id:
         album.cover_photo_id = None

--- a/backend/app/api/draw.py
+++ b/backend/app/api/draw.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field, field_validator
 from sqlmodel import Session
@@ -8,7 +10,7 @@ from app.core.database import get_session
 from app.core.logging import get_logger
 from app.models.photo import Photo
 from app.services import draw_service
-from app.services.draw_service import NoAvailablePhotosError
+from app.services.draw_service import AlbumNotFoundError, DrawPoolEmptyError, NoAvailablePhotosError
 
 router = APIRouter(prefix="/api/draw", tags=["draw"])
 logger = get_logger(__name__)
@@ -33,16 +35,20 @@ class DrawResponse(BaseModel):
     weight_reason: str | None = None
 
 
+class DrawPoolEmptyResponse(BaseModel):
+    pool_empty: Literal[True]
+
+
 class DrawResetResponse(BaseModel):
     ok: bool
     total_available: int
 
 
-@router.post("", response_model=DrawResponse)
+@router.post("", response_model=DrawResponse | DrawPoolEmptyResponse)
 def draw_card(
     request: DrawRequest,
     session: Session = Depends(get_session),
-) -> DrawResponse:
+) -> DrawResponse | DrawPoolEmptyResponse:
     try:
         photo, weight_reason = draw_service.draw_photo(
             session,
@@ -51,6 +57,10 @@ def draw_card(
             weight_mode=request.weight_mode,
             nearby_days=request.nearby_days,
         )
+    except AlbumNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Album not found") from exc
+    except DrawPoolEmptyError:
+        return DrawPoolEmptyResponse(pool_empty=True)
     except NoAvailablePhotosError as exc:
         raise HTTPException(status_code=404, detail="No more photos available to draw") from exc
 

--- a/backend/app/api/playlists.py
+++ b/backend/app/api/playlists.py
@@ -233,10 +233,12 @@ def remove_track_from_playlist(
         )
     ).first()
 
-    if link is not None:
-        session.delete(link)
-        session.flush()
-        compact_playlist_positions(session, playlist_id)
-        session.commit()
+    if link is None:
+        raise HTTPException(status_code=404, detail="Music track is not in playlist")
+
+    session.delete(link)
+    session.flush()
+    compact_playlist_positions(session, playlist_id)
+    session.commit()
 
     return OkResponse(ok=True)

--- a/backend/app/api/tags.py
+++ b/backend/app/api/tags.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import delete, func
 from sqlmodel import Session, select
 
@@ -13,7 +13,7 @@ router = APIRouter(prefix="/api", tags=["tags"])
 
 
 class TagCreateRequest(BaseModel):
-    name: str
+    name: str = Field(max_length=255)
 
 
 class AddPhotoTagsRequest(BaseModel):
@@ -130,6 +130,7 @@ def remove_tag_from_photo(
     session: Session = Depends(get_session),
 ) -> OkResponse:
     get_photo_or_404(photo_id, session)
+    get_tag_or_404(tag_id, session)
 
     link = session.exec(
         select(PhotoTag).where(
@@ -137,9 +138,11 @@ def remove_tag_from_photo(
             PhotoTag.tag_id == tag_id,
         )
     ).first()
-    if link is not None:
-        session.delete(link)
-        session.commit()
+    if link is None:
+        raise HTTPException(status_code=404, detail="Tag is not attached to photo")
+
+    session.delete(link)
+    session.commit()
 
     return OkResponse(ok=True)
 

--- a/backend/app/services/draw_service.py
+++ b/backend/app/services/draw_service.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 from sqlmodel import Session, select
 
-from app.models.album import PhotoAlbum
+from app.models.album import Album, PhotoAlbum
 from app.models.photo import Photo
 
 BASE_WEIGHT = 1.0
@@ -23,6 +23,14 @@ WEIGHT_PRESETS: dict[DrawWeightMode, dict[str, float]] = {
 
 
 class NoAvailablePhotosError(ValueError):
+    pass
+
+
+class DrawPoolEmptyError(ValueError):
+    pass
+
+
+class AlbumNotFoundError(ValueError):
     pass
 
 
@@ -132,20 +140,28 @@ def draw_photo(
     weight_mode: DrawWeightMode = "standard",
     nearby_days: int = 3,
 ) -> tuple[Photo, str | None]:
+    if album_id is not None and session.get(Album, album_id) is None:
+        raise AlbumNotFoundError
+
     candidates = query_draw_pool(
         session,
         album_id=album_id,
         exclude_ids=exclude_ids,
     )
-    if not candidates:
-        raise NoAvailablePhotosError
+    if candidates:
+        return choose_weighted_photo(
+            candidates,
+            today=today,
+            weight_mode=weight_mode,
+            nearby_days=nearby_days,
+        )
 
-    return choose_weighted_photo(
-        candidates,
-        today=today,
-        weight_mode=weight_mode,
-        nearby_days=nearby_days,
-    )
+    if exclude_ids:
+        unfiltered_candidates = query_draw_pool(session, album_id=album_id, exclude_ids=None)
+        if unfiltered_candidates:
+            raise DrawPoolEmptyError
+
+    raise NoAvailablePhotosError
 
 
 def count_available_photos(session: Session) -> int:

--- a/backend/tests/test_albums.py
+++ b/backend/tests/test_albums.py
@@ -150,3 +150,40 @@ def test_set_album_cover_photo(client: TestClient) -> None:
     payload = detail_response.json()
     assert payload["cover_photo_id"] == photo["id"]
     assert payload["cover_photo"].startswith(f"/api/photos/{photo['id']}/thumbnail?v=")
+
+
+def test_remove_missing_photo_association_returns_404(client: TestClient) -> None:
+    photo = upload_photo(client)
+    album = create_album(client)
+
+    response = client.delete(f"/api/albums/{album['id']}/photos/{photo['id']}")
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": "not_found",
+        "message": "Photo is not in album",
+        "status_code": 404,
+    }
+
+
+def test_album_name_rejects_more_than_255_characters(client: TestClient) -> None:
+    long_name = "a" * 256
+
+    create_response = client.post(
+        "/api/albums",
+        json={"name": long_name, "description": "too long"},
+    )
+    assert create_response.status_code == 422
+    create_payload = create_response.json()
+    assert create_payload["error"] == "validation_error"
+    assert "name" in create_payload["message"]
+
+    album = create_album(client)
+    update_response = client.put(
+        f"/api/albums/{album['id']}",
+        json={"name": long_name, "description": "too long", "cover_photo_id": None},
+    )
+    assert update_response.status_code == 422
+    update_payload = update_response.json()
+    assert update_payload["error"] == "validation_error"
+    assert "name" in update_payload["message"]

--- a/backend/tests/test_draw.py
+++ b/backend/tests/test_draw.py
@@ -63,18 +63,14 @@ def test_draw_returns_valid_photo(client: TestClient, session: Session) -> None:
     assert payload["weight_reason"] is None
 
 
-def test_draw_with_all_excluded_returns_404(client: TestClient, session: Session) -> None:
+def test_draw_with_all_excluded_returns_pool_empty(client: TestClient, session: Session) -> None:
     first = create_photo(session, filename="first")
     second = create_photo(session, filename="second")
 
     response = client.post("/api/draw", json={"exclude_ids": [first.id, second.id]})
 
-    assert response.status_code == 404
-    assert response.json() == {
-        "error": "not_found",
-        "message": "No more photos available to draw",
-        "status_code": 404,
-    }
+    assert response.status_code == 200
+    assert response.json() == {"pool_empty": True}
 
 
 def test_draw_with_album_filter_returns_only_album_photo(client: TestClient, session: Session) -> None:
@@ -96,6 +92,33 @@ def test_draw_with_album_filter_returns_only_album_photo(client: TestClient, ses
 
     assert response.status_code == 200
     assert response.json()["photo"]["id"] == in_album.id
+
+
+def test_draw_with_nonexistent_album_returns_404(client: TestClient) -> None:
+    response = client.post("/api/draw", json={"album_id": 999999, "exclude_ids": []})
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": "not_found",
+        "message": "Album not found",
+        "status_code": 404,
+    }
+
+
+def test_draw_with_empty_album_returns_404(client: TestClient, session: Session) -> None:
+    album = Album(name="Empty")
+    session.add(album)
+    session.commit()
+    session.refresh(album)
+
+    response = client.post("/api/draw", json={"album_id": album.id, "exclude_ids": []})
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": "not_found",
+        "message": "No more photos available to draw",
+        "status_code": 404,
+    }
 
 
 def test_draw_reset_returns_total_available(client: TestClient, session: Session) -> None:

--- a/backend/tests/test_playlists.py
+++ b/backend/tests/test_playlists.py
@@ -153,3 +153,19 @@ def test_album_playlist_association_set_and_clear(client: TestClient) -> None:
     album_after_clear = client.get(f"/api/albums/{album['id']}")
     assert album_after_clear.status_code == 200
     assert album_after_clear.json()["playlist_id"] is None
+
+
+def test_remove_missing_track_association_returns_404(client: TestClient) -> None:
+    track = upload_track(client, "lonely.wav")
+    create_response = client.post("/api/playlists", json={"name": "No Track Link"})
+    assert create_response.status_code == 201
+    playlist_id = create_response.json()["id"]
+
+    remove_response = client.delete(f"/api/playlists/{playlist_id}/tracks/{track['id']}")
+
+    assert remove_response.status_code == 404
+    assert remove_response.json() == {
+        "error": "not_found",
+        "message": "Music track is not in playlist",
+        "status_code": 404,
+    }

--- a/backend/tests/test_tags.py
+++ b/backend/tests/test_tags.py
@@ -94,3 +94,26 @@ def test_delete_tag_removes_all_photo_associations(client: TestClient) -> None:
     filtered_after_delete = client.get("/api/photos", params={"tag_id": tag["id"]})
     assert filtered_after_delete.status_code == 200
     assert filtered_after_delete.json()["total"] == 0
+
+
+def test_remove_missing_tag_association_returns_404(client: TestClient) -> None:
+    photo = upload_photo(client)
+    tag = create_tag(client, "detached")
+
+    response = client.delete(f"/api/photos/{photo['id']}/tags/{tag['id']}")
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": "not_found",
+        "message": "Tag is not attached to photo",
+        "status_code": 404,
+    }
+
+
+def test_tag_name_rejects_more_than_255_characters(client: TestClient) -> None:
+    response = client.post("/api/tags", json={"name": "x" * 256})
+
+    assert response.status_code == 422
+    payload = response.json()
+    assert payload["error"] == "validation_error"
+    assert "name" in payload["message"]

--- a/frontend/src/__tests__/components/OnboardingOverlay.test.ts
+++ b/frontend/src/__tests__/components/OnboardingOverlay.test.ts
@@ -77,6 +77,23 @@ describe('onboardingOverlay', () => {
     expect(wrapper.find('[data-testid="onboarding-overlay"]').exists()).toBe(false)
   })
 
+  it('renders when forceShow is enabled even if completion flag is true', async () => {
+    localStorage.setItem('ts-onboarding-complete', 'true')
+
+    const wrapper = mount(OnboardingOverlay, {
+      props: {
+        forceShow: true,
+      },
+      global: {
+        plugins: [i18n],
+      },
+    })
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="onboarding-overlay"]').exists()).toBe(true)
+  })
+
   it('advances through all steps with next button', async () => {
     const wrapper = await mountOverlay()
 

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -4,6 +4,18 @@
 @tailwind components;
 @tailwind utilities;
 
+html,
+body,
+#app {
+  width: 100%;
+  max-width: 100%;
+}
+
+html,
+body {
+  overflow-x: hidden;
+}
+
 body {
   margin: 0;
   min-height: 100vh;

--- a/frontend/src/components/OnboardingOverlay.vue
+++ b/frontend/src/components/OnboardingOverlay.vue
@@ -24,6 +24,11 @@ interface CompletionParticle {
   delay: number
 }
 
+const props = withDefaults(defineProps<{
+  forceShow?: boolean
+}>(), {
+  forceShow: false,
+})
 const STORAGE_KEY = 'ts-onboarding-complete'
 const STEP_TRANSITION_SECONDS = 0.3
 const DONE_ANIMATION_MS = 480
@@ -227,7 +232,7 @@ function handleWindowChange(): void {
 }
 
 onMounted(async () => {
-  if (localStorage.getItem(STORAGE_KEY) === 'true') {
+  if (!props.forceShow && localStorage.getItem(STORAGE_KEY) === 'true') {
     return
   }
 
@@ -271,12 +276,12 @@ onBeforeUnmount(() => {
     />
 
     <div
-      class="relative flex min-h-full items-start justify-center overflow-y-auto px-4 py-6"
+      class="pointer-events-none relative flex min-h-full items-start justify-center overflow-y-auto px-4 py-6"
       :style="{ paddingBottom: 'calc(var(--ts-player-main-padding, 5rem) + 1rem)' }"
     >
       <section
         ref="panelRef"
-        class="relative w-full max-w-lg overflow-hidden rounded-ts-lg border border-ts-border bg-ts-panel px-6 py-6 shadow-ts-md md:px-8 md:py-8"
+        class="pointer-events-auto relative z-10 w-full max-w-lg overflow-hidden rounded-ts-lg border border-ts-border bg-ts-panel px-6 py-6 shadow-ts-md md:px-8 md:py-8"
       >
         <div class="flex items-start justify-between gap-4">
           <p class="text-xs uppercase tracking-[0.14em] text-ts-muted/80">
@@ -285,7 +290,7 @@ onBeforeUnmount(() => {
           <button
             data-testid="onboarding-skip"
             type="button"
-            class="text-sm text-ts-muted transition hover:text-ts-text"
+            class="relative z-20 touch-manipulation text-sm text-ts-muted transition hover:text-ts-text"
             @click="onSkip"
           >
             {{ t('onboarding.skip') }}

--- a/frontend/src/components/TsLightbox.vue
+++ b/frontend/src/components/TsLightbox.vue
@@ -32,6 +32,7 @@ const imageSurfaceRef = ref<HTMLElement | null>(null)
 const imageRef = ref<HTMLImageElement | null>(null)
 const isRendered = ref(false)
 const contentVisible = ref(false)
+const isAnimating = ref(false)
 const currentIndex = ref(0)
 const prefersReducedMotion = ref(false)
 
@@ -198,9 +199,11 @@ function showInstantly(): void {
     gsapApi.set(backdrop, { opacity: 1 })
   }
   contentVisible.value = true
+  isAnimating.value = false
 }
 
 function runOpenAnimation(): void {
+  isAnimating.value = true
   const backdrop = backdropRef.value
   const surface = imageSurfaceRef.value
   const photo = currentPhoto.value
@@ -253,6 +256,7 @@ function runOpenAnimation(): void {
     onComplete: () => {
       contentVisible.value = true
       cleanupClone()
+      isAnimating.value = false
     },
   })
 
@@ -280,6 +284,7 @@ function runOpenAnimation(): void {
 function finalizeClose(emitModelUpdate: boolean): void {
   cleanupClone()
   killTimelines()
+  isAnimating.value = false
   contentVisible.value = false
   isRendered.value = false
   unlockBodyScroll()
@@ -289,6 +294,15 @@ function finalizeClose(emitModelUpdate: boolean): void {
 }
 
 function runCloseAnimation(emitModelUpdate: boolean): void {
+  killTimelines()
+  cleanupClone()
+  isAnimating.value = true
+
+  if (!contentVisible.value) {
+    finalizeClose(emitModelUpdate)
+    return
+  }
+
   const backdrop = backdropRef.value
   const image = imageRef.value
   const photo = currentPhoto.value
@@ -328,6 +342,9 @@ function runCloseAnimation(emitModelUpdate: boolean): void {
 }
 
 function openLightbox(): void {
+  killTimelines()
+  cleanupClone()
+
   if (props.photos.length === 0) {
     emit('update:open', false)
     return
@@ -337,6 +354,8 @@ function openLightbox(): void {
   activeOriginRect = props.originRect ? copyRect(props.originRect) : null
   activeOriginKind = props.originKind
   isRendered.value = true
+  contentVisible.value = false
+  isAnimating.value = true
   lockBodyScroll()
 
   nextTick(() => {
@@ -405,15 +424,12 @@ function handleMotionChange(event: MediaQueryListEvent): void {
 }
 
 watch(() => props.open, (open) => {
-  killTimelines()
-  cleanupClone()
-
   if (open) {
     openLightbox()
     return
   }
 
-  if (isRendered.value) {
+  if (isRendered.value || isAnimating.value) {
     runCloseAnimation(false)
   }
 }, { immediate: true })

--- a/frontend/src/composables/__tests__/useCardDraw.spec.ts
+++ b/frontend/src/composables/__tests__/useCardDraw.spec.ts
@@ -248,4 +248,20 @@ describe('useCardDraw', () => {
     expect(cardDraw.isDrawing.value).toBe(false)
     expect(cardDraw.errorMessage.value).toBe('No more photos available to draw')
   })
+
+  it('marks pool as empty when draw api reports pool exhaustion', async () => {
+    vi.mocked(drawApi.drawPhoto).mockResolvedValue({
+      pool_empty: true,
+    } as DrawResponse)
+
+    const cardDraw = useCardDraw()
+
+    await cardDraw.drawNextCard()
+
+    expect(cardDraw.poolEmpty.value).toBe(true)
+    expect(cardDraw.errorMessage.value).toBeNull()
+    expect(cardDraw.ceremonyState.value).toBe('IDLE')
+    expect(cardDraw.isDrawing.value).toBe(false)
+    expect(vi.mocked(gsapApi.gsap.timeline)).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/src/composables/useCardDraw.ts
+++ b/frontend/src/composables/useCardDraw.ts
@@ -128,6 +128,7 @@ export function useCardDraw() {
   const isDrawing = ref(false)
   const isScatterOpen = ref(false)
   const errorMessage = ref<string | null>(null)
+  const poolEmpty = ref(false)
   const lastWeightReason = ref<string | null>(null)
   const hiddenPileCardId = ref<number | null>(null)
 
@@ -165,6 +166,7 @@ export function useCardDraw() {
 
     isDrawing.value = true
     errorMessage.value = null
+    poolEmpty.value = false
     killCeremony()
 
     const reducedMotion = prefersReducedMotion()
@@ -177,6 +179,17 @@ export function useCardDraw() {
         weight_mode: settingsStore.drawWeightMode,
         nearby_days: settingsStore.drawNearbyDays,
       })
+      if (payload.pool_empty) {
+        ceremonyState.value = 'IDLE'
+        clearGhost()
+        poolEmpty.value = true
+        isDrawing.value = false
+        return
+      }
+
+      if (!payload.photo) {
+        throw new Error('Draw response is missing photo payload')
+      }
 
       const hadPreviousCard = !!drawStore.activeCard
       const previousCardId = drawStore.activeCard?.photo.id ?? null
@@ -190,9 +203,9 @@ export function useCardDraw() {
 
       drawStore.addDrawnCard({
         photo: payload.photo,
-        weightReason: payload.weight_reason,
+        weightReason: payload.weight_reason ?? null,
       })
-      lastWeightReason.value = payload.weight_reason
+      lastWeightReason.value = payload.weight_reason ?? null
 
       await nextTick()
 
@@ -362,6 +375,7 @@ export function useCardDraw() {
     catch (error) {
       ceremonyState.value = 'IDLE'
       clearGhost()
+      poolEmpty.value = false
 
       if (isAxiosError<{ detail?: string }>(error)) {
         errorMessage.value = error.response?.data?.detail ?? i18n.global.t('draw.drawFailed')
@@ -405,6 +419,7 @@ export function useCardDraw() {
     ceremonyState.value = 'IDLE'
     isScatterOpen.value = false
     errorMessage.value = null
+    poolEmpty.value = false
     lastWeightReason.value = null
   }
 
@@ -522,6 +537,7 @@ export function useCardDraw() {
     isDrawing,
     isScatterOpen,
     errorMessage,
+    poolEmpty,
     lastWeightReason,
     drawNextCard,
     openScatter,

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -84,6 +84,7 @@ const en: MessageSchema = {
     title: 'Albums',
     description: 'Create and browse albums with cover photos and quick counts.',
     namePlaceholder: 'Album name',
+    nameRequired: 'Album name is required',
     descPlaceholder: 'Description (optional)',
     createFailed: 'Failed to create album.',
     loadFailed: 'Failed to load albums.',

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -82,6 +82,7 @@ export default {
     title: '相册',
     description: '创建和浏览带有封面照片和数量统计的相册。',
     namePlaceholder: '相册名称',
+    nameRequired: '相册名称为必填项',
     descPlaceholder: '描述（可选）',
     createFailed: '创建相册失败。',
     loadFailed: '加载相册失败。',

--- a/frontend/src/pages/AlbumsPage.vue
+++ b/frontend/src/pages/AlbumsPage.vue
@@ -12,6 +12,7 @@ const albums = ref<Album[]>([])
 const loading = ref(false)
 const creating = ref(false)
 const errorMessage = ref<string | null>(null)
+const nameValidationMessage = ref<string | null>(null)
 
 const newName = ref('')
 const newDescription = ref('')
@@ -34,10 +35,16 @@ async function loadAlbums(): Promise<void> {
 
 async function handleCreateAlbum(): Promise<void> {
   const name = newName.value.trim()
-  if (!name || creating.value) {
+  if (creating.value) {
     return
   }
 
+  if (!name) {
+    nameValidationMessage.value = t('album.nameRequired')
+    return
+  }
+
+  nameValidationMessage.value = null
   creating.value = true
   errorMessage.value = null
 
@@ -55,6 +62,12 @@ async function handleCreateAlbum(): Promise<void> {
   }
   finally {
     creating.value = false
+  }
+}
+
+function onNameInput(): void {
+  if (newName.value.trim()) {
+    nameValidationMessage.value = null
   }
 }
 
@@ -82,7 +95,11 @@ onMounted(async () => {
         v-model="newName"
         type="text"
         :placeholder="$t('album.namePlaceholder')"
-        class="album-create-input rounded border border-white/15 bg-ts-panelSoft px-3 py-2 text-sm text-ts-text outline-none focus:border-ts-accent"
+        class="album-create-input rounded border bg-ts-panelSoft px-3 py-2 text-sm text-ts-text outline-none"
+        :class="nameValidationMessage
+          ? 'border-red-400/70 focus:border-red-300'
+          : 'border-white/15 focus:border-ts-accent'"
+        @input="onNameInput"
       >
       <input
         v-model="newDescription"
@@ -98,6 +115,10 @@ onMounted(async () => {
         {{ creating ? $t('common.creating') : $t('common.create') }}
       </button>
     </form>
+
+    <p v-if="nameValidationMessage" class="rounded border border-red-400/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+      {{ nameValidationMessage }}
+    </p>
 
     <p v-if="errorMessage" class="rounded border border-red-400/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
       {{ errorMessage }}

--- a/frontend/src/pages/HomePage.vue
+++ b/frontend/src/pages/HomePage.vue
@@ -5,6 +5,7 @@ import type { Photo } from '../types/photo'
 
 import { gsap } from 'gsap'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import CardDeck from '../components/draw/CardDeck.vue'
 import CardPile from '../components/draw/CardPile.vue'
 import CardScatter from '../components/draw/CardScatter.vue'
@@ -39,6 +40,7 @@ const SWIPE_ROTATION_FACTOR = 0.05
 
 const drawStore = useDrawStore()
 const settingsStore = useSettingsStore()
+const route = useRoute()
 const { playlistId, setContext, tracks } = useMusicPlayer()
 const albums = ref<Album[]>([])
 const touchStartX = ref<number | null>(null)
@@ -79,6 +81,7 @@ const {
   isDrawing,
   isScatterOpen,
   errorMessage,
+  poolEmpty,
   lastWeightReason,
   drawNextCard,
   openScatter,
@@ -113,6 +116,7 @@ const ceremonyClass = computed<Record<string, boolean>>(() => {
     'ceremony-display': state === 'DISPLAYING',
   }
 })
+const forceShowOnboarding = computed(() => route.name === 'onboarding-debug')
 
 function prefersReducedMotion(): boolean {
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
@@ -468,7 +472,10 @@ watch(
 
         <button
           type="button"
-          class="rounded border border-white/30 px-4 py-2 text-sm font-semibold text-ts-text/95 transition hover:border-white/50 hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60"
+          class="rounded border px-4 py-2 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-60"
+          :class="poolEmpty
+            ? 'border-ts-accent text-ts-accent shadow-glow hover:bg-ts-accent/15'
+            : 'border-white/30 text-ts-text/95 hover:border-white/50 hover:bg-white/10'"
           :disabled="!hasDrawnCards || isDrawing"
           @click="reshuffle"
         >
@@ -481,8 +488,24 @@ watch(
       </div>
     </header>
 
+    <div
+      v-if="poolEmpty"
+      class="flex flex-col items-start gap-2 rounded border border-ts-accent/45 bg-ts-accent/10 px-4 py-3 text-sm text-ts-accent md:flex-row md:items-center"
+    >
+      <p>
+        Card pool is empty. Click Reshuffle to continue drawing.
+      </p>
+      <button
+        type="button"
+        class="rounded border border-ts-accent/80 px-3 py-1.5 text-xs font-semibold text-ts-accent transition hover:bg-ts-accent/20"
+        @click="reshuffle"
+      >
+        {{ $t('draw.reshuffle') }}
+      </button>
+    </div>
+
     <p
-      v-if="errorMessage"
+      v-else-if="errorMessage"
       class="rounded border border-red-400/40 bg-red-500/10 px-4 py-3 text-sm text-red-200"
     >
       {{ errorMessage }}
@@ -599,7 +622,7 @@ watch(
       :origin-rect="lightboxOrigin"
       origin-kind="card"
     />
-    <OnboardingOverlay />
+    <OnboardingOverlay :force-show="forceShowOnboarding" />
   </section>
 </template>
 

--- a/frontend/src/pages/UploadPage.vue
+++ b/frontend/src/pages/UploadPage.vue
@@ -63,7 +63,10 @@ onMounted(async () => {
 </script>
 
 <template>
-  <section class="space-y-6">
+  <section
+    class="space-y-6 pb-6"
+    :style="{ paddingBottom: 'calc(var(--ts-player-main-padding, 5rem) + 1rem)' }"
+  >
     <header class="space-y-2">
       <h1 class="text-3xl font-semibold text-ts-accent">
         {{ $t('photo.uploadTitle') }}

--- a/frontend/src/pages/__tests__/AlbumsPage.spec.ts
+++ b/frontend/src/pages/__tests__/AlbumsPage.spec.ts
@@ -1,0 +1,38 @@
+import { flushPromises } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mountWithI18n } from '../../test-utils'
+import AlbumsPage from '../AlbumsPage.vue'
+
+vi.mock('../../services/album', () => ({
+  createAlbum: vi.fn(),
+  listAlbums: vi.fn(),
+}))
+
+const albumApi = await import('../../services/album')
+
+describe('albumsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(albumApi.listAlbums).mockResolvedValue({
+      items: [],
+      total: 0,
+    })
+  })
+
+  it('shows validation error when creating album with empty name', async () => {
+    const wrapper = mountWithI18n(AlbumsPage, {
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    })
+    await flushPromises()
+
+    await wrapper.get('form').trigger('submit.prevent')
+    await wrapper.vm.$nextTick()
+
+    expect(vi.mocked(albumApi.createAlbum)).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Album name is required')
+  })
+})

--- a/frontend/src/router/__tests__/index.spec.ts
+++ b/frontend/src/router/__tests__/index.spec.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+import router from '../index'
+
+describe('router', () => {
+  it('registers onboarding debug route', () => {
+    const route = router.getRoutes().find(item => item.name === 'onboarding-debug')
+
+    expect(route).toBeDefined()
+    expect(route?.path).toBe('/debug/onboarding')
+  })
+})

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -12,6 +12,7 @@ const router = createRouter({
   history: createWebHistory(),
   routes: [
     { path: '/', name: 'home', component: HomePage },
+    { path: '/debug/onboarding', name: 'onboarding-debug', component: HomePage },
     { path: '/albums', name: 'albums', component: AlbumsPage },
     { path: '/albums/:id', name: 'album-detail', component: AlbumDetailPage },
     { path: '/upload', name: 'upload', component: UploadPage },

--- a/frontend/src/services/draw.ts
+++ b/frontend/src/services/draw.ts
@@ -22,10 +22,17 @@ export interface DrawRequest {
   nearby_days?: number
 }
 
-export interface DrawResponse {
+export interface DrawSuccessResponse {
   photo: Photo
   weight_reason: string | null
+  pool_empty?: false
 }
+
+export interface DrawPoolEmptyResponse {
+  pool_empty: true
+}
+
+export type DrawResponse = DrawSuccessResponse | DrawPoolEmptyResponse
 
 export interface DrawResetResponse {
   ok: boolean


### PR DESCRIPTION
## Summary
- fix the listed P1 backend/frontend issues from tmp/docs/p1-bugs.md
- add explicit pool-empty draw response handling and user-facing reshuffle guidance
- harden lightbox/open-close animation state handling for rapid interactions
- fix mobile/layout issues (upload bottom overlap, horizontal overflow, onboarding skip clickability)
- add onboarding debug trigger route at /debug/onboarding for quick GET-based testing
- localize album empty-name validation message

## Validation
- backend: uv run ruff check . and uv run pytest (87 passed)
- frontend: un run lint, un run type-check, and un run test (182 passed)
